### PR TITLE
[#36] 상품 재고 기능 개발 - Pessimistic Lock 버전

### DIFF
--- a/src/main/java/com/fastshoppers/repository/ProductRepository.java
+++ b/src/main/java/com/fastshoppers/repository/ProductRepository.java
@@ -3,9 +3,18 @@ package com.fastshoppers.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
 
 import com.fastshoppers.entity.Product;
 
+import jakarta.persistence.LockModeType;
+
+@Repository
 public interface ProductRepository extends JpaRepository<Product, Integer> {
 	Optional<Product> findByProductUuid(String productUuid);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<Product> findById(Integer productId);
+
 }


### PR DESCRIPTION
## 12/ 17 추가 내용
### 관련 이슈
[#36 ] PESSIMISTIC LOCK을 사용한 상품 재고 기능 개발

### 변경 내용
1.  성능 비교 테스트를 위해, `Redis`로직을 삭제하고, `ProductRepository`의` Optional<Product> findById(Integer productId) `메서드에 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 을 추가하여 RDB에서 재고 데이터에 대한 읽기와 쓰기가 독점적으로 이루어지는 비관적 락 로직을 추가하였습니다. 

=> 리뷰와 성능 테스트를 위한 PR로, `merge`되지 않습니다.
