### PR TITLE
[#33] 그라파나, 프로메테우스 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ ext {
 }
 
 bootRun {
-	if (project.hasProperty('profile')) {
-		args = ["--spring.profiles.active=${profile}"]
-	}
+    if (project.hasProperty('profile')) {
+        args = ["--spring.profiles.active=${profile}"]
+    }
 }
 
 dependencies {
@@ -41,6 +41,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-data-redis"
     implementation "org.redisson:redisson-spring-boot-starter:${redissonVersion}"
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly "org.projectlombok:lombok"
     developmentOnly "org.springframework.boot:spring-boot-devtools"
     runtimeOnly "com.mysql:mysql-connector-j"
@@ -48,6 +51,7 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "com.h2database:h2"
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,23 @@ services:
     container_name: redis-container
     ports:
       - "6379:6379"
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus-container
+    volumes:
+      - ./prometheus:/etc/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    depends_on:
+      - mysql
+      - redis
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana-container
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'spring-boot-application'
+    scrape_interval: 10s
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ]

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -3,14 +3,12 @@ spring.datasource.url=jdbc:mysql://localhost:3307/fast-shoppers-db
 spring.datasource.username=root
 spring.datasource.password=fast-shoppers
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-
 #hibernate_show_sql option
 spring.jpa.properties.hibernate.show_sql=true
 #hibernate_format_option
 spring.jpa.properties.hibernate.format_sql=true
 #ddl_auto => create
 spring.jpa.hibernate.ddl-auto=create
-
 # for local-test - test DB Setting
 spring.datasource.localtest.url=jdbc:h2:mem:testdb
 spring.datasource.localtest.driverClassName=org.h2.Driver
@@ -25,4 +23,6 @@ token.access.expiry.milliseconds=1800000
 # redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+# end point expose
+management.endpoints.web.exposure.include=prometheus,health,info
 


### PR DESCRIPTION
## 24 / 03/ 12 추가 내용
### 관련 이슈
[#33 ] grafana & prometheus 연동

### 변경 내용
1. build.gradle에 spring-boot-starter-actuator 의존성과 micrometer-registry-prometheus 의존성을 추가하였습니다.
2. 특정 actuor endpoint가 외부에 노출되도록 application.properties를 수정하였습니다. 
3. 프로메테우스 설정파일인  prometheus.yml파일을 추가하였습니다.
4. docker-compose에 그라파나와 프로메테우스 관련 설정을 추가하였습니다.
